### PR TITLE
Add retries for device events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onosproject/onos-ztp
 go 1.12
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c // indirect
 	github.com/gofrs/flock v0.7.1 // indirect
 	github.com/golang/mock v1.3.1

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -98,7 +98,7 @@ func (m *Manager) Run() {
 	log.Info("Starting Manager")
 
 	// Start the device monitor and provisioner components.
-	m.monitor.Start(m.deviceChanel)
+	go m.monitor.Start(m.deviceChanel)
 	m.provisioner.Start(m.deviceChanel)
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -98,12 +98,8 @@ func (m *Manager) Run() {
 	log.Info("Starting Manager")
 
 	// Start the device monitor and provisioner components.
-	err := m.monitor.Start(m.deviceChanel)
-	if err != nil {
-		log.Error("Unable to start device monitor", err)
-	} else {
-		m.provisioner.Start(m.deviceChanel)
-	}
+	m.monitor.Start(m.deviceChanel)
+	m.provisioner.Start(m.deviceChanel)
 }
 
 // Close kills the channels and manager related objects

--- a/pkg/southbound/monitor.go
+++ b/pkg/southbound/monitor.go
@@ -82,22 +82,20 @@ func (m *DeviceMonitor) watchEvents(deviceEvents chan<- *device.Device) error {
 		return err
 	}
 
-	go func() {
-		log.Info("Listening for device events")
-		for {
-			event, err := topoEvents.Recv()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				log.Error("Unable to receive device event: ", err)
-			} else if event.Type == device.ListResponse_ADDED || event.Type == device.ListResponse_UPDATED {
-				log.Infof("Detected addition or update of device %s", event.Device.GetID())
-				queueDevice(deviceEvents, event.Device, event.Type == device.ListResponse_UPDATED)
-			}
+	log.Info("Listening for device events")
+	for {
+		event, err := topoEvents.Recv()
+		if err == io.EOF {
+			log.Error(err)
+			return nil
 		}
-	}()
-	return nil
+		if err != nil {
+			log.Error("Unable to receive device event: ", err)
+		} else if event.Type == device.ListResponse_ADDED || event.Type == device.ListResponse_UPDATED {
+			log.Infof("Detected addition or update of device %s", event.Device.GetID())
+			queueDevice(deviceEvents, event.Device, event.Type == device.ListResponse_UPDATED)
+		}
+	}
 }
 
 // Stop stops the device monitor and associated resources

--- a/pkg/southbound/monitor.go
+++ b/pkg/southbound/monitor.go
@@ -17,6 +17,8 @@ package southbound
 
 import (
 	"context"
+	"errors"
+	"github.com/cenkalti/backoff"
 	"github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	"io"
@@ -27,7 +29,7 @@ import (
 // DeviceMonitor is responsible for monitoring topology for new device events.
 type DeviceMonitor struct {
 	client device.DeviceServiceClient
-	events *chan *device.Device
+	events chan<- *device.Device
 }
 
 const (
@@ -50,9 +52,29 @@ func (m *DeviceMonitor) Init(dialOptions ...grpc.DialOption) error {
 	return nil
 }
 
-// Start kicks off the device monitor listening for the topology device add events.
-func (m *DeviceMonitor) Start(deviceEvents chan *device.Device) error {
-	m.events = &deviceEvents
+// Start starts listening for events from the DeviceService
+func (m *DeviceMonitor) Start(ch chan<- *device.Device) {
+	// Retry continuously to listen for devices from the device service. The root retry loop is constant, so
+	// when the device listener disconnects, a new connection will be attempted a second later. Each connection
+	// iteration is performed using an exponential backoff algorithm, ensuring the client doesn't attempt to connect
+	// to a missing service constantly.
+	_ = backoff.Retry(func() error {
+		operation := func() error {
+			return m.watchEvents(ch)
+		}
+
+		// Use exponential backoff until the client is able to list devices. This operation should never return
+		// an error since we don't use the error type required to fail the exponential backoff operation.
+		_ = backoff.Retry(operation, backoff.NewExponentialBackOff())
+
+		// Return a placeholder error to ensure the connection is retried.
+		return errors.New("retry")
+	}, backoff.NewConstantBackOff(1*time.Second))
+}
+
+// watchEvents opens a device event stream
+func (m *DeviceMonitor) watchEvents(deviceEvents chan<- *device.Device) error {
+	m.events = deviceEvents
 	topoEvents, err := m.client.List(context.Background(), &device.ListRequest{
 		Subscribe: true,
 	})
@@ -80,10 +102,10 @@ func (m *DeviceMonitor) Start(deviceEvents chan *device.Device) error {
 
 // Stop stops the device monitor and associated resources
 func (m *DeviceMonitor) Stop() {
-	defer close(*m.events)
+	defer close(m.events)
 }
 
-func queueDevice(devices chan *device.Device, d *device.Device, updated bool) {
+func queueDevice(devices chan<- *device.Device, d *device.Device, updated bool) {
 	// HACK:  Induce delay before delivering the event onto the channel
 	var t *time.Timer
 	if updated {

--- a/pkg/southbound/monitor_test.go
+++ b/pkg/southbound/monitor_test.go
@@ -56,8 +56,7 @@ func Test_Basics(t *testing.T) {
 	dispatchUpdateDelay = 1 * time.Microsecond
 	monitor := DeviceMonitor{m, nil}
 	ch := make(chan *device.Device)
-	err := monitor.Start(ch)
-	assert.NilError(t, err, "unexpected error")
+	monitor.Start(ch)
 
 	dev := <-ch
 	assert.Assert(t, dev.GetID() == "foobar", "incorrect device")
@@ -79,8 +78,7 @@ func Test_ListError(t *testing.T) {
 
 	monitor := DeviceMonitor{m, nil}
 	ch := make(chan *device.Device)
-	err := monitor.Start(ch)
-	assert.Error(t, err, "unexpected EOF", "wrong error")
+	monitor.Start(ch)
 	time.Sleep(100 * time.Millisecond)
 	monitor.Stop()
 }

--- a/pkg/southbound/monitor_test.go
+++ b/pkg/southbound/monitor_test.go
@@ -50,13 +50,14 @@ func Test_Basics(t *testing.T) {
 	stream.EXPECT().Recv().
 		Return(nil, io.ErrClosedPipe)
 	stream.EXPECT().Recv().
-		Return(nil, io.EOF)
+		Return(nil, io.EOF).
+		AnyTimes()
 
 	dispatchAddDelay = 1 * time.Microsecond
 	dispatchUpdateDelay = 1 * time.Microsecond
 	monitor := DeviceMonitor{m, nil}
 	ch := make(chan *device.Device)
-	monitor.Start(ch)
+	go monitor.Start(ch)
 
 	dev := <-ch
 	assert.Assert(t, dev.GetID() == "foobar", "incorrect device")
@@ -74,11 +75,12 @@ func Test_ListError(t *testing.T) {
 	m := mock.NewMockDeviceServiceClient(ctrl)
 
 	m.EXPECT().List(gomock.Any(), gomock.Any()).
-		Return(nil, io.ErrUnexpectedEOF)
+		Return(nil, io.ErrUnexpectedEOF).
+		AnyTimes()
 
 	monitor := DeviceMonitor{m, nil}
 	ch := make(chan *device.Device)
-	monitor.Start(ch)
+	go monitor.Start(ch)
 	time.Sleep(100 * time.Millisecond)
 	monitor.Stop()
 }


### PR DESCRIPTION
This PR implements retries for ztp. As implemented, killing topo nodes can result in duplicate device events sent to ztp. Each time ztp reconnects, all existing devices plus future events will be sent by the topo service. The client must deduplicate devices itself if duplicate devices will have a negative affect on ztp.